### PR TITLE
feat: Allow loading custom prompt from file

### DIFF
--- a/prompt.txt
+++ b/prompt.txt
@@ -1,0 +1,30 @@
+You are an expert librarian tasked with categorizing technical ebooks based on their summaries.
+Your goal is to return a **JSON object** with the following three specific keys: "path", "summary", and "keywords".
+
+**Instructions for generating the JSON object:**
+
+1.  **"path"**:
+    *   This must be a list of strings representing the categorization path.
+    *   The list must have a depth of exactly {depth} levels.
+    *   The first level must be one of the main categories provided in the "Available Categories" section.
+    *   For subsequent levels, use existing subcategories from the "Available Categories" list whenever they are a good match.
+    *   Current Mode: **{mode}**.
+        *   If **Strict mode**, you MUST strictly use categories from the "Available Categories" list.
+        *   If **Flexible mode**, and if no existing subcategory is a suitable match, you are allowed to propose a new subcategory. Prefix any new subcategory you create with "NEW: " (e.g., "NEW: Advanced Quantum Computing").
+
+2.  **"summary"**:
+    *   Provide a concise summary of the ebook, approximately 5-10 sentences long, based on the provided "Book summary to analyze".
+    *   The summary should capture the main topics and purpose of the book.
+
+3.  **"keywords"**:
+    *   Generate a list of exactly 10 relevant technical keywords that accurately describe the book's content.
+
+**Available Categories:**
+{category_text}
+
+**Book summary to analyze:**
+---
+{book_summary}
+---
+
+Ensure your entire response is ONLY the JSON object, without any introductory text, explanations, or markdown formatting surrounding the JSON.


### PR DESCRIPTION
This commit introduces the ability to specify a custom prompt template for the LLM via a command-line argument.

New functionality:
- Added a `--load_prompt <filename>` command-line argument to `ebook_organizer.py`.
- If you use this argument and the specified file exists, its content will be used as the prompt template for the LLM. This allows you to easily experiment with different prompts without modifying the core script.
- The `BookProcessor` has been updated to handle this new argument and load the prompt accordingly. If the file is not found or the argument is not provided, the script falls back to the default built-in prompt.
- A new `prompt.txt` file has been added to the repository. This file contains a refined and more detailed prompt example, ensuring it requests a JSON object with "path", "summary", and "keywords" keys, and includes the necessary placeholders (`{depth}`, `{mode}`, `{category_text}`, `{book_summary}`) for dynamic population.

The changes ensure that the existing f-string formatting capabilities for the prompt are maintained, whether using the default prompt or a custom one loaded from a file. Error handling has been implemented for cases where the specified prompt file cannot be read or formatted, ensuring the script defaults to the built-in prompt.